### PR TITLE
Remove broken composer provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         }
     },
     "provide": {
-        "psr/cache": "^1.0.1",
         "psr/cache-implementation": "1.0"
     },
     "license": "MIT"


### PR DESCRIPTION
This package does not provide the interfaces of psr/cache but only an implementation of the interfaces.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that installing psr/cache is not necessary as it is already provided.

Refs composer/composer#9316